### PR TITLE
Add request logging middleware and request ID

### DIFF
--- a/backend/api/dependencies/logging_middleware.py
+++ b/backend/api/dependencies/logging_middleware.py
@@ -1,0 +1,46 @@
+import time
+import logging
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+from .request_id import get_request_id, REQUEST_ID_HEADER
+
+logger = logging.getLogger("trace.api")
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request_id = get_request_id(request)
+        request.state.request_id = request_id
+
+        start = time.perf_counter()
+        try:
+            response: Response = await call_next(request)
+        except Exception:
+            duration_ms = int((time.perf_counter() - start) * 1000)
+            logger.exception(
+                "request_failed",
+                extra={
+                    "requestId": request_id,
+                    "method": request.method,
+                    "path": request.url.path,
+                    "duration_ms": duration_ms,
+                },
+            )
+            raise
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+
+        response.headers[REQUEST_ID_HEADER] = request_id
+
+        logger.info(
+            "request_complete",
+            extra={
+                "requestId": request_id,
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration_ms": duration_ms,
+            },
+        )
+        return response

--- a/backend/api/dependencies/request_id.py
+++ b/backend/api/dependencies/request_id.py
@@ -1,0 +1,8 @@
+from uuid import uuid4
+from fastapi import Request
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+def get_request_id(request: Request) -> str:
+    incoming = request.headers.get(REQUEST_ID_HEADER)
+    return incoming if incoming else str(uuid4())


### PR DESCRIPTION
Introduce request_id utility and a RequestLoggingMiddleware to add request tracing and structured logs. request_id.py generates or preserves X-Request-ID from incoming headers. logging_middleware.py measures request duration, logs exceptions and completions (logger 'trace.api'), attaches the request ID to request.state and response headers. Register the middleware in main.py to enable global request logging and tracing.