### PR TITLE
Add GitHub Actions auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy Backend to EC2
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run deploy.sh on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          script: |
+            cd ~/CapstoneProject
+            chmod +x deploy.sh
+            ./deploy.sh


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automated backend deployment to an EC2 instance. The workflow is triggered on pushes to the `main` branch and can also be run manually. It ensures only one deployment runs at a time and uses SSH to execute the deployment script remotely.

Deployment automation:

* Added `.github/workflows/deploy.yml` to automate backend deployment to EC2 using the `appleboy/ssh-action`. The workflow runs on pushes to `main` and via manual dispatch, ensuring concurrency control and executing `deploy.sh` on the remote server.