### PR TITLE
Add Dataset API endpoints

### DIFF
--- a/backend/api/models/dataset.py
+++ b/backend/api/models/dataset.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, String, Integer, ForeignKey, Float
+from sqlalchemy.orm import relationship
+
+from backend.api.dependencies.database import Base
+
+
+class DatasetTemplate(Base):
+    __tablename__ = "dataset_template"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, nullable=False)
+    description = Column(String(255))
+
+    transactions = relationship("DatasetTransaction", back_populates="template",
+                                cascade="all, delete-orphan")
+
+class DatasetTransaction(Base):
+    __tablename__ = "dataset_transaction"
+    id = Column(Integer, primary_key=True, index=True)
+    template_id = Column(Integer, ForeignKey("dataset_template.id"))
+
+    store_name = Column(String(255), nullable=False)
+    category = Column(String(50), nullable=False)
+    cost = Column(Float, nullable=False)
+
+    day_offset = Column(Integer, nullable=False, default=0)
+    template = relationship("DatasetTemplate", back_populates="transactions")

--- a/backend/api/routers/dataset.py
+++ b/backend/api/routers/dataset.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.api.dependencies.auth import get_current_user
+from backend.api.dependencies.database import get_db
+from backend.api.models.dataset import DatasetTemplate, DatasetTransaction
+from backend.api.models.transaction import Transaction
+from backend.api.models.user import User
+from backend.api.schemas.dataset import DatasetTemplateResponse, ApplyDatasetResponse
+
+router = APIRouter(prefix="/datasets", tags=["Datasets"])
+
+@router.get("/", response_model=List[DatasetTemplateResponse])
+def get_dataset_templates(db: Session = Depends(get_db)):
+    templates = db.query(DatasetTemplate).all()
+    return templates
+
+@router.post("/{template_id}/apply", response_model=ApplyDatasetResponse)
+def apply_dataset(
+        template_id: int,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user)
+):
+    template = db.query(DatasetTemplate).filter(DatasetTemplate.id == template_id).first()
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    existing_tx_count = db.query(Transaction).filter(Transaction.user_id == current_user.id).count()
+    if existing_tx_count > 0:
+        raise HTTPException(status_code=400, detail="User already has transactions, Cannot apply template.")
+
+    template_txs = db.query(DatasetTransaction).filter(DatasetTransaction.id == template_id).all()
+
+    if not template_txs:
+        return ApplyDatasetResponse(message="Template has no transactions.", transactions_added=0)
+
+    new_transactions = []
+    today = datetime.utcnow()
+    for t_tx in template_txs:
+        tx_date = today + timedelta(days = t_tx.day_offset)
+
+        new_tx = Transaction(
+            user_id = current_user.id,
+            store_name=t_tx.store_name,
+            category=t_tx.category,
+            cost=t_tx.cost,
+            date=tx_date,
+        )
+        new_transactions.append(new_tx)
+
+    db.add_all(new_transactions)
+    db.commit()
+
+    return ApplyDatasetResponse(
+        message=f"Template '{template.name}' applied successfully.",
+        transactions_added=len(new_transactions)
+    )

--- a/backend/api/routers/index.py
+++ b/backend/api/routers/index.py
@@ -1,4 +1,4 @@
-from . import user, transaction, subscription, budget, simulation, analytics, insight, summary, prediction
+from . import user, transaction, subscription, budget, simulation, analytics, insight, summary, prediction, dataset
 from fastapi import Depends
 from backend.api.dependencies.rate_limit import get_rate_limit_dependency
 
@@ -17,3 +17,4 @@ def load_routes(app):
     app.include_router(insight.router, dependencies=[rate_limit])
     app.include_router(summary.router, dependencies=[rate_limit])
     app.include_router(prediction.router, dependencies=[rate_limit])
+    app.include_router(dataset.router, dependencies=[rate_limit])

--- a/backend/api/schemas/dataset.py
+++ b/backend/api/schemas/dataset.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class DatasetTemplateResponse(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+
+    class Config:
+        from_attributes = True
+
+class ApplyDatasetResponse(BaseModel):
+    message: str
+    transactions_added: int


### PR DESCRIPTION
- Add a GET /datasets/ endpoint to retrieve all available dataset templates.
- Add a POST /datasets/{template_id}/apply endpoint to generate and assign template transactions to the authenticated user.
- Implement a validation safeguard to return a 400 error if the user already has existing transactions, preventing accidental data pollution.
- Calculate transaction dates dynamically by adding the template's day_offset to the current UTC datetime.