### PR TITLE
Prediction Empty/Error State UX #86

### DIFF
--- a/frontend/src/components/dashboard/DashboardLayouts.css
+++ b/frontend/src/components/dashboard/DashboardLayouts.css
@@ -158,6 +158,10 @@ h3 {
   margin-bottom: 12px;
 }
 
+.mobile-predicted-card {
+  min-height: 220px;
+}
+
 .tx-list {
   display: grid;
   gap: 10px;
@@ -324,6 +328,7 @@ h3 {
 .desktop-predicted-panel {
   grid-area: predicted;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0.12) 100%), var(--surface);
+  min-height: 260px;
 }
 
 .tx-table {

--- a/frontend/src/components/dashboard/DesktopDashboard.jsx
+++ b/frontend/src/components/dashboard/DesktopDashboard.jsx
@@ -20,6 +20,7 @@ function DesktopDashboard({
   predictedTransactions,
   loadingPredictions,
   predictionError,
+  onRetryPredictions,
 }) {
   const budgetTotal = health ? `$${Number(health.budget_limit).toFixed(2)}` : "--";
   const spentTotal = health ? `$${Number(health.total_spent).toFixed(2)}` : "--";
@@ -137,6 +138,7 @@ function DesktopDashboard({
             transactions={predictedTransactions}
             loading={loadingPredictions}
             error={predictionError}
+            onRetry={onRetryPredictions}
           />
         </section>
       </div>

--- a/frontend/src/components/dashboard/MobileDashboard.jsx
+++ b/frontend/src/components/dashboard/MobileDashboard.jsx
@@ -21,6 +21,7 @@ function MobileDashboard({
   predictedTransactions,
   loadingPredictions,
   predictionError,
+  onRetryPredictions,
 }) {
   const budgetTotal = health ? `$${Number(health.budget_limit).toFixed(2)}` : "--";
   const spentTotal = health ? `$${Number(health.total_spent).toFixed(2)}` : "--";
@@ -123,6 +124,7 @@ function MobileDashboard({
           transactions={predictedTransactions}
           loading={loadingPredictions}
           error={predictionError}
+          onRetry={onRetryPredictions}
           defaultExpanded={false}
         />
       </section>

--- a/frontend/src/components/insight/InsightCard.css
+++ b/frontend/src/components/insight/InsightCard.css
@@ -108,6 +108,28 @@
   align-items: center;
 }
 
+.insight-card__retry-btn {
+  border: none;
+  border-radius: 999px;
+  background: #22223b;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+  min-height: 34px;
+  padding: 0 14px;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.insight-card__retry-btn:hover:not(:disabled) {
+  background: #4a4e69;
+  transform: translateY(-1px);
+}
+
+.insight-card__retry-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
 .insight-card__toggle {
   border: none;
   border-radius: 999px;
@@ -201,9 +223,43 @@
   color: #4a4e69;
 }
 
+.insight-card__state {
+  display: grid;
+  gap: 8px;
+  min-height: 138px;
+  align-content: center;
+}
+
+.insight-card__state-title {
+  margin: 0;
+  font-size: 0.96rem;
+  font-weight: 700;
+  color: #22223b;
+}
+
+.insight-card__state-message {
+  margin: 0;
+  color: #4a4e69;
+  line-height: 1.45;
+}
+
 .insight-card__error {
   background: rgba(180, 35, 24, 0.12);
   color: #6f0014;
+}
+
+.insight-card__error .insight-card__state-title,
+.insight-card__error .insight-card__state-message {
+  color: #6f0014;
+}
+
+.insight-card__retry-btn--inline {
+  justify-self: start;
+  margin-top: 4px;
+}
+
+.prediction-insight-card .insight-card__details-inner {
+  min-height: 150px;
 }
 
 .insight-card__tone-positive {

--- a/frontend/src/components/insight/PredictedTransactionsInsight.jsx
+++ b/frontend/src/components/insight/PredictedTransactionsInsight.jsx
@@ -7,6 +7,7 @@ function PredictedTransactionsInsight({
   loading = false,
   error = "",
   defaultExpanded = true,
+  onRetry,
 }) {
   const validPredictions = (transactions || []).filter(
     (transaction) => transaction?.amount !== null && transaction?.amount !== undefined
@@ -16,22 +17,64 @@ function PredictedTransactionsInsight({
     (sum, transaction) => sum + Number(transaction.amount || 0),
     0
   );
+  const canRetry = typeof onRetry === "function";
+  const isFailureState = !loading && Boolean(error);
+  const isEmptyState = !loading && !error && validPredictions.length === 0;
+  const statusLabel = loading
+    ? "Refreshing predictions"
+    : isFailureState
+      ? "Prediction service unavailable"
+      : isEmptyState
+        ? "No predicted transactions yet"
+        : `${validPredictions.length} modeled transaction${validPredictions.length === 1 ? "" : "s"}`;
 
   return (
     <InsightCard
       title="Predicted Transactions"
       value={loading ? "Analyzing..." : String(validPredictions.length)}
-      description="Upcoming modeled charges and spending events detected from prediction history."
+      description={statusLabel}
       status={error ? "negative" : validPredictions.length > 0 ? "warning" : "neutral"}
       icon={<PredictionIcon />}
       defaultExpanded={defaultExpanded}
+      className="prediction-insight-card"
+      action={isFailureState && canRetry ? (
+        <button
+          type="button"
+          className="insight-card__retry-btn"
+          onClick={onRetry}
+          disabled={loading}
+        >
+          Retry
+        </button>
+      ) : null}
     >
       {loading ? (
-        <div className="insight-card__empty">Loading prediction history...</div>
+        <div className="insight-card__state insight-card__empty">
+          <p className="insight-card__state-title">Loading prediction history</p>
+          <p className="insight-card__state-message">We are calculating upcoming spending signals now.</p>
+        </div>
       ) : error ? (
-        <div className="insight-card__error" role="alert">{error}</div>
+        <div className="insight-card__state insight-card__error" role="alert">
+          <p className="insight-card__state-title">Could not load predictions</p>
+          <p className="insight-card__state-message">{error}</p>
+          {canRetry ? (
+            <button
+              type="button"
+              className="insight-card__retry-btn insight-card__retry-btn--inline"
+              onClick={onRetry}
+              disabled={loading}
+            >
+              Try again
+            </button>
+          ) : null}
+        </div>
       ) : validPredictions.length === 0 ? (
-        <div className="insight-card__empty">No predicted transactions available yet.</div>
+        <div className="insight-card__state insight-card__empty">
+          <p className="insight-card__state-title">No predicted transactions available</p>
+          <p className="insight-card__state-message">
+            Keep adding transactions. Predictions will appear after we detect recurring spending patterns.
+          </p>
+        </div>
       ) : (
         <div className="insight-card__list">
           <div className="insight-card__meta">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -68,39 +68,46 @@ function Dashboard() {
     [transactions]
   );
 
-  useEffect(() => {
+  const loadPredictions = useCallback(async () => {
     if (isDemoMode) {
       setLoadingPredictions(false);
       setPredictionError("");
+      setPredictions(currentDataset?.predictions || []);
       return;
     }
 
-    const loadPredictions = async () => {
-      setLoadingPredictions(true);
-      setPredictionError("");
+    setLoadingPredictions(true);
+    setPredictionError("");
 
-      try {
-        const response = await API.get("/prediction/history");
+    try {
+      const response = await API.get("/prediction/history");
 
-        const mapped = (response.data || []).map((item, index) => ({
-          id: item.id || `pred-${index}`,
-          name: item.target_data || "Predicted Transaction",
-          amount: Number(item.predicted_spending) || 0,
-        }));
+      const mapped = (response.data || []).map((item, index) => ({
+        id: item.id || `pred-${index}`,
+        name: item.target_data || "Predicted Transaction",
+        amount: Number(item.predicted_spending) || 0,
+      }));
 
-        setPredictions(mapped);
-      } catch (error) {
-        setPredictionError(
-          normalizeApiError(error, "Failed to load predicted transactions.")
-        );
-        setPredictions([]);
-      } finally {
-        setLoadingPredictions(false);
-      }
-    };
+      setPredictions(mapped);
+    } catch (error) {
+      setPredictionError(
+        normalizeApiError(error, "Failed to load predicted transactions.")
+      );
+      setPredictions([]);
+    } finally {
+      setLoadingPredictions(false);
+    }
+  }, [
+    currentDataset,
+    isDemoMode,
+    setPredictions,
+    setLoadingPredictions,
+    setPredictionError,
+  ]);
 
+  useEffect(() => {
     loadPredictions();
-  }, [isDemoMode, token, setPredictions, setLoadingPredictions, setPredictionError]);
+  }, [loadPredictions, token]);
 
   const loadSubscriptionInsight = useCallback(async () => {
     if (isDemoMode) {
@@ -316,6 +323,7 @@ function Dashboard() {
           predictedTransactions={activePredictions}
           loadingPredictions={activeLoadingPredictions}
           predictionError={activePredictionError}
+          onRetryPredictions={loadPredictions}
         />
         <DemoWalkthrough />
       </>
@@ -340,6 +348,7 @@ function Dashboard() {
         predictedTransactions={activePredictions}
         loadingPredictions={activeLoadingPredictions}
         predictionError={activePredictionError}
+        onRetryPredictions={loadPredictions}
       />
       <DemoWalkthrough />
     </>


### PR DESCRIPTION
Prediction fetch now has a reusable retry handler in Dashboard.jsx (line 71)

Retry prop wired through desktop/mobile dashboard components DesktopDashboard.jsx (line 23)
DesktopDashboard.jsx (line 141)
MobileDashboard.jsx (line 24)
MobileDashboard.jsx (line 127)

Prediction empty/error UX + retry UI implemented in insight card PredictedTransactionsInsight.jsx (line 10)

Layout-collapse prevention and state styling added